### PR TITLE
allowing PhoneNumberField to be read as well

### DIFF
--- a/drfpasswordless/utils.py
+++ b/drfpasswordless/utils.py
@@ -163,9 +163,14 @@ def send_sms_with_callback_token(user, mobile_token, **kwargs):
 
             from twilio.rest import Client
             twilio_client = Client(os.environ['TWILIO_ACCOUNT_SID'], os.environ['TWILIO_AUTH_TOKEN'])
+
+            to_number = getattr(user, api_settings.PASSWORDLESS_USER_MOBILE_FIELD_NAME)
+            if to_number.__class__.__name__ == 'PhoneNumber':
+                to_number = to_number.__str__()
+
             twilio_client.messages.create(
                 body=base_string % mobile_token.key,
-                to=getattr(user, api_settings.PASSWORDLESS_USER_MOBILE_FIELD_NAME),
+                to=to_number,
                 from_=api_settings.PASSWORDLESS_MOBILE_NOREPLY_NUMBER
             )
             return True


### PR DESCRIPTION
I like using this package: https://github.com/stefanfoulis/django-phonenumber-field because it's very thorough in cleaning phonenumber's. 

However at the moment it can't be used. Don't know if this is the right way to go about this. But I didn't want to bother you with an extra dependency. So now I check if the name of the class is 'PhoneNumber'.

Let me know if you have questions.