### PR TITLE
Introduce a way to override how auth tokens are created

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,13 @@ DEFAULTS = {
 
     # Automatically send verification email or sms when a user changes their alias.
     'PASSWORDLESS_AUTO_SEND_VERIFICATION_TOKEN': False,
+
+    # What function is called to construct an authentication tokens when
+    # exchanging a passwordless token for a real user auth token. This function
+    # should take a user and return a tuple of two values. The first value is
+    # the token itself, the second is a boolean value representating whether
+    # the token was newly created.
+    'PASSWORDLESS_AUTH_TOKEN_CREATOR': 'drfpasswordless.utils.create_authentication_token'
 }
 ```
 

--- a/drfpasswordless/settings.py
+++ b/drfpasswordless/settings.py
@@ -69,6 +69,9 @@ DEFAULTS = {
     # Automatically send verification email or sms when a user changes their alias.
     'PASSWORDLESS_AUTO_SEND_VERIFICATION_TOKEN': False,
 
+    # What function is called to construct an authentication tokens when
+    # exchanging a passwordless token for a real user auth token.
+    'PASSWORDLESS_AUTH_TOKEN_CREATOR': 'drfpasswordless.utils.create_authentication_token'
 }
 
 # List of settings that may be in string import notation.

--- a/drfpasswordless/utils.py
+++ b/drfpasswordless/utils.py
@@ -5,6 +5,7 @@ from django.core.exceptions import PermissionDenied
 from django.core.mail import send_mail
 from django.template import loader
 from django.utils import timezone
+from rest_framework.authtoken.models import Token
 from drfpasswordless.models import CallbackToken
 from drfpasswordless.settings import api_settings
 
@@ -189,3 +190,8 @@ def send_sms_with_callback_token(user, mobile_token, **kwargs):
                   "Number entered was {}".format(user.id, getattr(user, api_settings.PASSWORDLESS_USER_MOBILE_FIELD_NAME)))
         logger.debug(e)
         return False
+
+
+def create_authentication_token(user):
+    """ Default way to create an authentication token"""
+    return Token.objects.get_or_create(user=user)

--- a/drfpasswordless/views.py
+++ b/drfpasswordless/views.py
@@ -1,6 +1,6 @@
 import logging
+from django.utils.module_loading import import_string
 from rest_framework import parsers, renderers, status
-from rest_framework.authtoken.models import Token
 from rest_framework.response import Response
 from rest_framework.permissions import AllowAny, IsAuthenticated 
 from rest_framework.views import APIView
@@ -130,7 +130,8 @@ class AbstractBaseObtainAuthToken(APIView):
         serializer = self.serializer_class(data=request.data)
         if serializer.is_valid(raise_exception=True):
             user = serializer.validated_data['user']
-            token = Token.objects.get_or_create(user=user)[0]
+            token_creator = import_string(api_settings.PASSWORDLESS_AUTH_TOKEN_CREATOR)
+            (token, _) = token_creator(user)
 
             if token:
                 # Return our key for consumption.


### PR DESCRIPTION
This creates a new setting PASSWORDLESS_AUTH_TOKEN_CREATOR. This is a
string representing the function used to construct an authentication
token after receiving a valid passwordless token.


Notes: It was not obvious to me how to run the tests, so I did not write tests. Happy to do so with some instructions.