### PR TITLE
Lock the password only, if the user was created

### DIFF
--- a/drfpasswordless/serializers.py
+++ b/drfpasswordless/serializers.py
@@ -27,6 +27,7 @@ class AbstractBaseAliasAuthenticationSerializer(serializers.Serializer):
     Abstract class that returns a callback token based on the field given
     Returns a token if valid, None or a message if not.
     """
+
     @property
     def alias_type(self):
         # The alias type, either email or mobile
@@ -41,7 +42,12 @@ class AbstractBaseAliasAuthenticationSerializer(serializers.Serializer):
 
             if api_settings.PASSWORDLESS_REGISTER_NEW_USERS is True:
                 # If new aliases should register new users.
-                user, created = User.objects.get_or_create(**{self.alias_type: alias})
+                user, user_created = User.objects.get_or_create(
+                    **{self.alias_type: alias})
+
+                if user_created:
+                    user.set_unusable_password()
+                    user.save()
             else:
                 # If new aliases should not register new users.
                 try:

--- a/drfpasswordless/views.py
+++ b/drfpasswordless/views.py
@@ -130,12 +130,7 @@ class AbstractBaseObtainAuthToken(APIView):
         serializer = self.serializer_class(data=request.data)
         if serializer.is_valid(raise_exception=True):
             user = serializer.validated_data['user']
-            token, created = Token.objects.get_or_create(user=user)
-
-            if created:
-                # Initially set an unusable password if a user is created through this.
-                user.set_unusable_password()
-                user.save()
+            token = Token.objects.get_or_create(user=user)[0]
 
             if token:
                 # Return our key for consumption.


### PR DESCRIPTION
drfpasswordless locks the password each time, if the Token object
was created and not updated. This means that the user that uses the
Token login in the first time has no longer a password, because
it will deleted.

This commit changes the logic to only lock the password, if the user
was generated by drfpasswordless.

Resolves #19