### PR TITLE
Generate tokens in a cryptographically secure way

### DIFF
--- a/drfpasswordless/models.py
+++ b/drfpasswordless/models.py
@@ -1,8 +1,8 @@
 import uuid
-from random import randint
 from django.db import models
 from django.conf import settings
-
+import string
+from django.utils.crypto import get_random_string
 
 def generate_hex_token():
     return uuid.uuid1().hex
@@ -13,7 +13,7 @@ def generate_numeric_token():
     Generate a random 6 digit string of numbers.
     We use this formatting to allow leading 0s.
     """
-    return str("%06d" % randint(0, 999999))
+    return generate_random_string(length=6, allowed_chars=string.digits)
 
 
 class CallbackTokenManger(models.Manager):

--- a/drfpasswordless/models.py
+++ b/drfpasswordless/models.py
@@ -13,7 +13,7 @@ def generate_numeric_token():
     Generate a random 6 digit string of numbers.
     We use this formatting to allow leading 0s.
     """
-    return generate_random_string(length=6, allowed_chars=string.digits)
+    return get_random_string(length=6, allowed_chars=string.digits)
 
 
 class CallbackTokenManger(models.Manager):


### PR DESCRIPTION
This doesn't _really_ matter, as they're only 6 chars, but it's definitely nice!

This relies on Django's [`generate_random_string`](https://github.com/django/django/blob/master/django/utils/crypto.py#L37), which uses Python's `secrets` library, which is considered cryptographically secure.

The UUID-based tokens aren't generated in quite the same way, as I don't _think_ UUID1 is especially secure, but I didn't want to swap out to UUID4 (which is), as i'm not sure if anything else is depending on them being UUID1, as this change would be breaking.