### PR TITLE
don't default verified fields to True on user creation

### DIFF
--- a/drfpasswordless/signals.py
+++ b/drfpasswordless/signals.py
@@ -83,7 +83,7 @@ def update_alias_verification(sender, instance, **kwargs):
 
                 except User.DoesNotExist:
                     # User probably is just initially being created
-                    setattr(instance, email_verified_field, True)
+                    return
 
             if api_settings.PASSWORDLESS_USER_MARK_MOBILE_VERIFIED is True:
                 """
@@ -115,4 +115,4 @@ def update_alias_verification(sender, instance, **kwargs):
 
                 except User.DoesNotExist:
                     # User probably is just initially being created
-                    setattr(instance, mobile_verified_field, True)
+                    pass


### PR DESCRIPTION
If the User doesn't exist, the verified fields should not be set to True by default. This can result in the verified fields marked erroneously.
- In `update_alias_verification` the `instance.id` check is insufficient for identifying whether `pre_save` is being called on create or update. 
    -  `id` can be set in the application and not by the db. e.g. when using uuid as primary keys.
    - `id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)`
