### PR TITLE
Python 3.7+ & DRF 3.10+

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-django = {version=">=2.2.9"}
+django = "*"
 djangorestframework = "*"
 twilio = "*"
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8ae138dcfe4013caed1472e616189e11b5782ebb66f0671b6888ae819e0e40af"
+            "sha256": "f0f9f6967df59400d5550c543378da3d5eb701ed86fcd06fe42f7e4265759d56"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -104,10 +104,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293",
-                "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"
+                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
+                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
             ],
-            "version": "==1.25.7"
+            "version": "==1.25.8"
         }
     },
     "develop": {
@@ -394,10 +394,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293",
-                "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"
+                "sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc",
+                "sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc"
             ],
-            "version": "==1.25.7"
+            "version": "==1.25.8"
         },
         "wcwidth": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ curl -X POST -d "token=815381" localhost:8000/callback/auth/
 Requirements
 ============
 
-- Python (3.6+)
-- Django (2.0+)
-- Django Rest Framework + AuthToken (3.6+)
+- Python (3.7+)
+- Django (2.2+)
+- Django Rest Framework + AuthToken (3.10+)
 - Python-Twilio (Optional, for mobile.)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     flake8
-    py37-django22-drf{37,38,39}
+    py37-django22-drf{310,311}
+    py37-django30-drf{310,311}
 
 [testenv]
 commands =
@@ -11,9 +12,9 @@ deps =
     pytest-cov
     pytest-django
     django22: Django==2.2.*
-    drf37: djangorestframework==3.7.*
-    drf38: djangorestframework==3.8.*
-    drf39: djangorestframework==3.9.*
+    django30: Django==3.0.*
+    drf310: djangorestframework==3.10.*
+    drf311: djangorestframework==3.11.*
 setenv =
 	PYTHONPATH = {toxinidir}
 


### PR DESCRIPTION
This removes Python 2 support and requires `django-rest-framework` 3.10+.