### PR TITLE
replace instance id to pk

### DIFF
--- a/drfpasswordless/apps.py
+++ b/drfpasswordless/apps.py
@@ -1,6 +1,7 @@
 from django.apps import AppConfig
 from django.utils.translation import gettext_lazy as _
 
+
 class DrfpasswordlessConfig(AppConfig):
     name = 'drfpasswordless'
     verbose = _("DRF Passwordless")

--- a/drfpasswordless/models.py
+++ b/drfpasswordless/models.py
@@ -4,6 +4,7 @@ from django.conf import settings
 import string
 from django.utils.crypto import get_random_string
 
+
 def generate_hex_token():
     return uuid.uuid1().hex
 

--- a/drfpasswordless/serializers.py
+++ b/drfpasswordless/serializers.py
@@ -46,7 +46,7 @@ class AbstractBaseAliasAuthenticationSerializer(serializers.Serializer):
                 try:
                     user = User.objects.get(**{self.alias_type+'__iexact': alias})
                 except User.DoesNotExist:
-                    user = User.objects.create(**{self.alias_type: alias})
+                    user = User(**{self.alias_type: alias})
                     user.set_unusable_password()
                     user.save()
             else:

--- a/drfpasswordless/serializers.py
+++ b/drfpasswordless/serializers.py
@@ -44,10 +44,10 @@ class AbstractBaseAliasAuthenticationSerializer(serializers.Serializer):
 
             if api_settings.PASSWORDLESS_REGISTER_NEW_USERS is True:
                 # If new aliases should register new users.
-                user, user_created = User.objects.get_or_create(
-                    **{self.alias_type: alias})
-
-                if user_created:
+                try:
+                    user = User.objects.get(**{self.alias_type+'__iexact': alias})
+                except User.DoesNotExist:
+                    user = User.objects.create(**{self.alias_type: alias})
                     user.set_unusable_password()
                     user.save()
             else:

--- a/drfpasswordless/serializers.py
+++ b/drfpasswordless/serializers.py
@@ -9,6 +9,7 @@ from drfpasswordless.models import CallbackToken
 from drfpasswordless.settings import api_settings
 from drfpasswordless.utils import authenticate_by_token, verify_user_alias, validate_token_age
 
+
 logger = logging.getLogger(__name__)
 User = get_user_model()
 
@@ -296,5 +297,3 @@ class TokenResponseSerializer(serializers.Serializer):
     """
     token = serializers.CharField(source='key')
     key = serializers.CharField(write_only=True)
-
-

--- a/drfpasswordless/settings.py
+++ b/drfpasswordless/settings.py
@@ -51,6 +51,9 @@ DEFAULTS = {
     # The message sent to mobile users logging in. Takes one string.
     'PASSWORDLESS_MOBILE_MESSAGE': "Use this code to log in: %s",
 
+    # The mobile sms service
+    'PASSWORDLESS_MOBILE_BACKEND': "sms.twilio.backend",
+
     # Registers previously unseen aliases as new users.
     'PASSWORDLESS_REGISTER_NEW_USERS': True,
 

--- a/drfpasswordless/signals.py
+++ b/drfpasswordless/signals.py
@@ -16,7 +16,7 @@ def invalidate_previous_tokens(sender, instance, created, **kwargs):
     Invalidates all previously issued tokens of that type when a new one is created, used, or anything like that.
     """
     if isinstance(instance, CallbackToken):
-        CallbackToken.objects.active().filter(user=instance.user, type=instance.type).exclude(id=instance.id).update(is_active=False)
+        CallbackToken.objects.active().filter(user=instance.user, type=instance.type).exclude(pk=instance.pk).update(is_active=False)
 
 
 @receiver(signals.pre_save, sender=CallbackToken)
@@ -40,7 +40,7 @@ def update_alias_verification(sender, instance, **kwargs):
     """
     if isinstance(instance, User):
 
-        if instance.id:
+        if instance.pk:
 
             if api_settings.PASSWORDLESS_USER_MARK_EMAIL_VERIFIED is True:
                 """
@@ -51,7 +51,7 @@ def update_alias_verification(sender, instance, **kwargs):
 
                 # Verify that this is an existing instance and not a new one.
                 try:
-                    user_old = User.objects.get(id=instance.id)  # Pre-save object
+                    user_old = User.objects.get(pk=instance.pk)  # Pre-save object
                     instance_email = getattr(instance, email_field)  # Incoming Email
                     old_email = getattr(user_old, email_field)  # Pre-save object email
 
@@ -87,7 +87,7 @@ def update_alias_verification(sender, instance, **kwargs):
 
                 # Verify that this is an existing instance and not a new one.
                 try:
-                    user_old = User.objects.get(id=instance.id)  # Pre-save object
+                    user_old = User.objects.get(pk=instance.pk)  # Pre-save object
                     instance_mobile = getattr(instance, mobile_field)  # Incoming mobile
                     old_mobile = getattr(user_old, mobile_field)  # Pre-save object mobile
 

--- a/drfpasswordless/sms/twilio.py
+++ b/drfpasswordless/sms/twilio.py
@@ -1,4 +1,5 @@
 from twilio.rest import Client
+import os
 
 
 def backend(body, to, from_):

--- a/drfpasswordless/sms/twilio.py
+++ b/drfpasswordless/sms/twilio.py
@@ -1,0 +1,13 @@
+from twilio.rest import Client
+
+
+def backend(body, to, from_):
+    twilio_client = Client(os.environ['TWILIO_ACCOUNT_SID'], os.environ['TWILIO_AUTH_TOKEN'])
+
+    twilio_client.messages.create(
+        body=body,
+        to=to,
+        from_=from_
+    )
+
+    return True

--- a/drfpasswordless/utils.py
+++ b/drfpasswordless/utils.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.core.mail import send_mail
@@ -171,7 +170,7 @@ def send_sms_with_callback_token(user, mobile_token, **kwargs):
             body = base_string % mobile_token.key,
             to = to_number,
             from_ = api_settings.PASSWORDLESS_MOBILE_NOREPLY_NUMBER
-
+            # we import a service to send sms
             client = import_string(api_settings.PASSWORDLESS_MOBILE_BACKEND)
             
             return client(body, to, from_)

--- a/drfpasswordless/views.py
+++ b/drfpasswordless/views.py
@@ -145,7 +145,7 @@ class AbstractBaseObtainAuthToken(APIView):
 
             if token:
                 TokenSerializer = import_string(api_settings.PASSWORDLESS_AUTH_TOKEN_SERIALIZER)
-                token_serializer = TokenSerializer(data=token.__dict__, partial=True)
+                token_serializer = TokenSerializer(data=token, partial=True)
                 if token_serializer.is_valid():
                     # Return our key for consumption.
                     return Response(token_serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
When using the custom model of the user, where the primary key is overridden, the following will fly out

_minisample:_
```
class CustomUser():
    uuid = models.UUIDField(
        primary_key=True
    )
```