### PR TITLE
Demo Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,15 @@ DEFAULTS = {
     # exchanging a passwordless token for a real user auth token.
     'PASSWORDLESS_AUTH_TOKEN_SERIALIZER': 'drfpasswordless.serializers.TokenResponseSerializer'
 
+    # A dictionary of demo user's primary key mapped to their static pin
+    'PASSWORDLESS_DEMO_USERS': {},
+
+    # configurable function for sending email
+    'PASSWORDLESS_EMAIL_CALLBACK': 'drfpasswordless.utils.send_email_with_callback_token'
+    # configurable function for sending sms
+    'PASSWORDLESS_SMS_CALLBACK': 'drfpasswordless.utils.send_sms_with_callback_token'
+
+
 }
 ```
 

--- a/drfpasswordless/admin.py
+++ b/drfpasswordless/admin.py
@@ -28,7 +28,7 @@ class CallbackInline(AbstractCallbackTokenInline):
 
 
 class AbstractCallbackTokenAdmin(UserLinkMixin, admin.ModelAdmin):
-    readonly_fields = ('created_at', 'user', 'key', 'type',)
-    list_display = ('created_at', UserLinkMixin.LINK_TO_USER_FIELD, 'key', 'type', 'is_active')
-    fields = ('created_at', 'user', 'key', 'type', 'is_active')
+    readonly_fields = ('created_at', 'user', 'key', 'type', 'to_alias_type')
+    list_display = ('created_at', UserLinkMixin.LINK_TO_USER_FIELD, 'key', 'type', 'is_active', 'to_alias_type')
+    fields = ('created_at', 'user', 'key', 'type', 'is_active', 'to_alias_type')
     extra = 0

--- a/drfpasswordless/serializers.py
+++ b/drfpasswordless/serializers.py
@@ -232,10 +232,11 @@ class CallbackTokenAuthSerializer(AbstractBaseCallbackTokenSerializer):
                 msg = _('Invalid Token')
                 raise serializers.ValidationError(msg)
         except User.DoesNotExist:
-            msg = _('Invalid alias parameters provided.')
+            msg = _('Invalid user alias parameters provided.')
             raise serializers.ValidationError(msg)
         except ValidationError:
             msg = _('Invalid alias parameters provided.')
+            raise
             raise serializers.ValidationError(msg)
 
 

--- a/drfpasswordless/serializers.py
+++ b/drfpasswordless/serializers.py
@@ -236,7 +236,6 @@ class CallbackTokenAuthSerializer(AbstractBaseCallbackTokenSerializer):
             raise serializers.ValidationError(msg)
         except ValidationError:
             msg = _('Invalid alias parameters provided.')
-            raise
             raise serializers.ValidationError(msg)
 
 

--- a/drfpasswordless/services.py
+++ b/drfpasswordless/services.py
@@ -12,7 +12,7 @@ class TokenService(object):
         token = create_callback_token_for_user(user, alias_type, token_type)
         send_action = None
 
-        if user.pk in api_settings.DEMO_USERS.keys():
+        if user.pk in api_settings.PASSWORDLESS_DEMO_USERS.keys():
             return True
         if alias_type == 'email':
             send_action = send_email_with_callback_token

--- a/drfpasswordless/services.py
+++ b/drfpasswordless/services.py
@@ -1,8 +1,7 @@
+from django.utils.module_loading import import_string
 from drfpasswordless.settings import api_settings
 from drfpasswordless.utils import (
     create_callback_token_for_user,
-    send_email_with_callback_token,
-    send_sms_with_callback_token
 )
 
 
@@ -15,9 +14,9 @@ class TokenService(object):
         if user.pk in api_settings.PASSWORDLESS_DEMO_USERS.keys():
             return True
         if alias_type == 'email':
-            send_action = send_email_with_callback_token
+            send_action = import_string(api_settings.PASSWORDLESS_EMAIL_CALLBACK)
         elif alias_type == 'mobile':
-            send_action = send_sms_with_callback_token
+            send_action = import_string(api_settings.PASSWORDLESS_SMS_CALLBACK)
         # Send to alias
         success = send_action(user, token, **message_payload)
         return success

--- a/drfpasswordless/services.py
+++ b/drfpasswordless/services.py
@@ -1,3 +1,4 @@
+from drfpasswordless.settings import api_settings
 from drfpasswordless.utils import (
     create_callback_token_for_user,
     send_email_with_callback_token,
@@ -10,6 +11,9 @@ class TokenService(object):
     def send_token(user, alias_type, token_type, **message_payload):
         token = create_callback_token_for_user(user, alias_type, token_type)
         send_action = None
+
+        if user.pk in api_settings.DEMO_USERS.keys():
+            return True
         if alias_type == 'email':
             send_action = send_email_with_callback_token
         elif alias_type == 'mobile':

--- a/drfpasswordless/settings.py
+++ b/drfpasswordless/settings.py
@@ -84,7 +84,7 @@ DEFAULTS = {
     'PASSWORDLESS_AUTH_TOKEN_SERIALIZER': 'drfpasswordless.serializers.TokenResponseSerializer',
 
     # A dictionary of demo user's primary key mapped to their static pin
-    'DEMO_USERS': {},
+    'PASSWORDLESS_DEMO_USERS': {},
 }
 
 # List of settings that may be in string import notation.

--- a/drfpasswordless/settings.py
+++ b/drfpasswordless/settings.py
@@ -85,6 +85,9 @@ DEFAULTS = {
 
     # A dictionary of demo user's primary key mapped to their static pin
     'PASSWORDLESS_DEMO_USERS': {},
+    'PASSWORDLESS_EMAIL_CALLBACK': 'drfpasswordless.utils.send_email_with_callback_token',
+    'PASSWORDLESS_SMS_CALLBACK': 'drfpasswordless.utils.send_sms_with_callback_token',
+
 }
 
 # List of settings that may be in string import notation.

--- a/drfpasswordless/settings.py
+++ b/drfpasswordless/settings.py
@@ -81,7 +81,10 @@ DEFAULTS = {
 
     # What function is called to construct a serializer for drf tokens when
     # exchanging a passwordless token for a real user auth token.
-    'PASSWORDLESS_AUTH_TOKEN_SERIALIZER': 'drfpasswordless.serializers.TokenResponseSerializer'
+    'PASSWORDLESS_AUTH_TOKEN_SERIALIZER': 'drfpasswordless.serializers.TokenResponseSerializer',
+
+    # A dictionary of demo user's primary key mapped to their static pin
+    'DEMO_USERS': {},
 }
 
 # List of settings that may be in string import notation.

--- a/drfpasswordless/signals.py
+++ b/drfpasswordless/signals.py
@@ -16,7 +16,7 @@ def invalidate_previous_tokens(sender, instance, created, **kwargs):
     Invalidates all previously issued tokens of that type when a new one is created, used, or anything like that.
     """
 
-    if instance.user.pk in api_settings.DEMO_USERS.keys():
+    if instance.user.pk in api_settings.PASSWORDLESS_DEMO_USERS.keys():
         return
 
     if isinstance(instance, CallbackToken):

--- a/drfpasswordless/signals.py
+++ b/drfpasswordless/signals.py
@@ -15,6 +15,10 @@ def invalidate_previous_tokens(sender, instance, created, **kwargs):
     """
     Invalidates all previously issued tokens of that type when a new one is created, used, or anything like that.
     """
+
+    if instance.user.pk in api_settings.DEMO_USERS.keys():
+        return
+
     if isinstance(instance, CallbackToken):
         CallbackToken.objects.active().filter(user=instance.user, type=instance.type).exclude(id=instance.id).update(is_active=False)
 

--- a/drfpasswordless/utils.py
+++ b/drfpasswordless/utils.py
@@ -39,14 +39,14 @@ def create_callback_token_for_user(user, alias_type, token_type):
     token = None
     alias_type_u = alias_type.upper()
     to_alias_field = getattr(api_settings, f'PASSWORDLESS_USER_{alias_type_u}_FIELD_NAME')
-    if user.pk in api_settings.DEMO_USERS.keys():
+    if user.pk in api_settings.PASSWORDLESS_DEMO_USERS.keys():
         token = CallbackToken.objects.filter(user=user).first()
         if token:
             return token
         else:
             return CallbackToken.objects.create(
                 user=user,
-                key=api_settings.DEMO_USERS[user.pk],
+                key=api_settings.PASSWORDLESS_DEMO_USERS[user.pk],
                 to_alias_type=token_type,
                 to_alias=getattr(user, to_alias_field)
             )
@@ -73,7 +73,7 @@ def validate_token_age(callback_token):
         token = CallbackToken.objects.get(key=callback_token, is_active=True)
         seconds = (timezone.now() - token.created_at).total_seconds()
         token_expiry_time = api_settings.PASSWORDLESS_TOKEN_EXPIRE_TIME
-        if token.user.pk in api_settings.DEMO_USERS.keys():
+        if token.user.pk in api_settings.PASSWORDLESS_DEMO_USERS.keys():
             return True
         if seconds <= token_expiry_time:
             return True

--- a/drfpasswordless/utils.py
+++ b/drfpasswordless/utils.py
@@ -48,7 +48,8 @@ def create_callback_token_for_user(user, alias_type, token_type):
                 user=user,
                 key=api_settings.PASSWORDLESS_DEMO_USERS[user.pk],
                 to_alias_type=token_type,
-                to_alias=getattr(user, to_alias_field)
+                to_alias=getattr(user, to_alias_field),
+                type=token_type
             )
     
     token = CallbackToken.objects.create(user=user,

--- a/drfpasswordless/utils.py
+++ b/drfpasswordless/utils.py
@@ -47,7 +47,7 @@ def create_callback_token_for_user(user, alias_type, token_type):
             return CallbackToken.objects.create(
                 user=user,
                 key=api_settings.PASSWORDLESS_DEMO_USERS[user.pk],
-                to_alias_type=token_type,
+                to_alias_type=alias_type_u,
                 to_alias=getattr(user, to_alias_field),
                 type=token_type
             )


### PR DESCRIPTION
This pull request allows the user to add demo users like:

```
    'PASSWORDLESS_DEMO_USERS': {
        1: '123456',

    },

```

where 1 is the primary_key of the user and '123456' is a static pin.  

I based this off of https://github.com/charleshan/django-rest-framework-passwordless/commits/master

I think we could instead add a field that is evaluated as bool similar to PASSWORDLESS_USER_MOBILE_VERIFIED_FIELD_NAME and have it set which users are demo users. Both ways really have different downsides and upsides.  A demo user pretty much has to be a permanent user with Apple. 

Let me know if you have any input.

This is in references to #45 