### PR TITLE
Configurable token length

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,12 +183,13 @@ token, specify your template name with this setting:
 ```bash
 PASSWORDLESS_AUTH = {
    ...
-  'PASSWORDLESS_EMAIL_TOKEN_HTML_TEMPLATE_NAME': "mytemplate.html"
+  'PASSWORDLESS_EMAIL_TOKEN_HTML_TEMPLATE_NAME': "mytemplate.html",
+  'PASSWORDLESS_TOKEN_LENGTH': 6
 }
 ```
 
 The template renders a single variable ``{{ callback_token }}`` which is
-the 6 digit callback token being sent.
+the 6 (or defined as above) digit callback token being sent.
 
 Contact Point Validation
 ========================

--- a/drfpasswordless/models.py
+++ b/drfpasswordless/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.conf import settings
 import string
 from django.utils.crypto import get_random_string
+from drfpasswordless.settings import api_settings
 
 def generate_hex_token():
     return uuid.uuid1().hex
@@ -60,7 +61,7 @@ class CallbackToken(AbstractBaseCallbackToken):
     TOKEN_TYPE_VERIFY = 'VERIFY'
     TOKEN_TYPES = ((TOKEN_TYPE_AUTH, 'Auth'), (TOKEN_TYPE_VERIFY, 'Verify'))
 
-    key = models.CharField(default=generate_numeric_token, max_length=6)
+    key = models.CharField(default=generate_numeric_token, max_length=api_settings.PASSWORDLESS_TOKEN_LENGTH, min_length=api_settings.PASSWORDLESS_TOKEN_LENGTH)
     type = models.CharField(max_length=20, choices=TOKEN_TYPES)
 
     class Meta(AbstractBaseCallbackToken.Meta):

--- a/drfpasswordless/models.py
+++ b/drfpasswordless/models.py
@@ -61,7 +61,7 @@ class CallbackToken(AbstractBaseCallbackToken):
     TOKEN_TYPE_VERIFY = 'VERIFY'
     TOKEN_TYPES = ((TOKEN_TYPE_AUTH, 'Auth'), (TOKEN_TYPE_VERIFY, 'Verify'))
 
-    key = models.CharField(default=generate_numeric_token, max_length=api_settings.PASSWORDLESS_TOKEN_LENGTH, min_length=api_settings.PASSWORDLESS_TOKEN_LENGTH)
+    key = models.CharField(default=generate_numeric_token, max_length=api_settings.PASSWORDLESS_TOKEN_LENGTH)
     type = models.CharField(max_length=20, choices=TOKEN_TYPES)
 
     class Meta(AbstractBaseCallbackToken.Meta):

--- a/drfpasswordless/models.py
+++ b/drfpasswordless/models.py
@@ -61,7 +61,7 @@ class CallbackToken(AbstractBaseCallbackToken):
     TOKEN_TYPE_VERIFY = 'VERIFY'
     TOKEN_TYPES = ((TOKEN_TYPE_AUTH, 'Auth'), (TOKEN_TYPE_VERIFY, 'Verify'))
 
-    key = models.CharField(default=generate_numeric_token, max_length=api_settings.PASSWORDLESS_TOKEN_LENGTH)
+    key = models.CharField(default=generate_numeric_token, max_length=24)
     type = models.CharField(max_length=20, choices=TOKEN_TYPES)
 
     class Meta(AbstractBaseCallbackToken.Meta):

--- a/drfpasswordless/models.py
+++ b/drfpasswordless/models.py
@@ -14,7 +14,7 @@ def generate_numeric_token():
     Generate a random 6 digit string of numbers.
     We use this formatting to allow leading 0s.
     """
-    return get_random_string(length=6, allowed_chars=string.digits)
+    return get_random_string(length=api_settings.PASSWORDLESS_TOKEN_LENGTH, allowed_chars=string.digits)
 
 
 class CallbackTokenManger(models.Manager):

--- a/drfpasswordless/serializers.py
+++ b/drfpasswordless/serializers.py
@@ -175,7 +175,7 @@ class AbstractBaseCallbackTokenSerializer(serializers.Serializer):
 
     email = serializers.EmailField(required=False)  # Needs to be required=false to require both.
     mobile = serializers.CharField(required=False, validators=[phone_regex], max_length=17)
-    token = TokenField(min_length=6, max_length=6, validators=[token_age_validator])
+    token = TokenField(min_length=api_settings.PASSWORDLESS_TOKEN_LENGTH, max_length=api_settings.PASSWORDLESS_TOKEN_LENGTH, validators=[token_age_validator])
 
     def validate_alias(self, attrs):
         email = attrs.get('email', None)

--- a/drfpasswordless/settings.py
+++ b/drfpasswordless/settings.py
@@ -87,7 +87,10 @@ DEFAULTS = {
     'PASSWORDLESS_DEMO_USERS': {},
     'PASSWORDLESS_EMAIL_CALLBACK': 'drfpasswordless.utils.send_email_with_callback_token',
     'PASSWORDLESS_SMS_CALLBACK': 'drfpasswordless.utils.send_sms_with_callback_token',
-
+    
+    # The length of the token to send in email or sms
+    'PASSWORDLESS_TOKEN_LENGTH': 6,
+    
     # Token Generation Retry Count
     'PASSWORDLESS_TOKEN_GENERATION_ATTEMPTS': 3
 }

--- a/drfpasswordless/settings.py
+++ b/drfpasswordless/settings.py
@@ -88,7 +88,7 @@ DEFAULTS = {
     'PASSWORDLESS_EMAIL_CALLBACK': 'drfpasswordless.utils.send_email_with_callback_token',
     'PASSWORDLESS_SMS_CALLBACK': 'drfpasswordless.utils.send_sms_with_callback_token',
     
-    # The length of the token to send in email or sms
+    # The length of the token to send in email or sms, maximum 24
     'PASSWORDLESS_TOKEN_LENGTH': 6,
     
     # Token Generation Retry Count


### PR DESCRIPTION
The sent token was 6 digits long with a fixed value. This commit contains the necessary changes to be able to configure as we want.

credit @bgervan