### PR TITLE
Fix bug where demo tokens are not created

### DIFF
--- a/drfpasswordless/utils.py
+++ b/drfpasswordless/utils.py
@@ -40,17 +40,13 @@ def create_callback_token_for_user(user, alias_type, token_type):
     alias_type_u = alias_type.upper()
     to_alias_field = getattr(api_settings, f'PASSWORDLESS_USER_{alias_type_u}_FIELD_NAME')
     if user.pk in api_settings.PASSWORDLESS_DEMO_USERS.keys():
-        token = CallbackToken.objects.filter(user=user).first()
-        if token:
-            return token
-        else:
-            return CallbackToken.objects.create(
-                user=user,
-                key=api_settings.PASSWORDLESS_DEMO_USERS[user.pk],
-                to_alias_type=alias_type_u,
-                to_alias=getattr(user, to_alias_field),
-                type=token_type
-            )
+        return CallbackToken.objects.create(
+            user=user,
+            key=api_settings.PASSWORDLESS_DEMO_USERS[user.pk],
+            to_alias_type=alias_type_u,
+            to_alias=getattr(user, to_alias_field),
+            type=token_type
+        )
     
     token = CallbackToken.objects.create(user=user,
                                             to_alias_type=alias_type_u,


### PR DESCRIPTION
It looks like these lines are preventing the creation of new tokens with predefined keys so the current implementation doesn't work with existing users. This pull request simply removes those lines.
https://github.com/aaronn/django-rest-framework-passwordless/blob/0a382e9809c5599a3b2b774453538abb5fe25361/drfpasswordless/utils.py#L43-L53