### PR TITLE
[django-4.0] change use of deprecated ugettext_lazy to gettext_lazy

### DIFF
--- a/drfpasswordless/serializers.py
+++ b/drfpasswordless/serializers.py
@@ -1,5 +1,5 @@
 import logging
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.core.validators import RegexValidator
@@ -299,5 +299,3 @@ class TokenResponseSerializer(serializers.Serializer):
     """
     token = serializers.CharField(source='key')
     key = serializers.CharField(write_only=True)
-
-

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -1,6 +1,6 @@
 from rest_framework import status
 from rest_framework.authtoken.models import Token
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from rest_framework.test import APITestCase
 from django.contrib.auth import get_user_model
 from django.urls import reverse


### PR DESCRIPTION
https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0

> django.utils.translation.ugettext(), ugettext_lazy(), ugettext_noop(), ungettext(), and ungettext_lazy() are removed.