### PR TITLE
Use `gettext_lazy` instead of `ugettext_lazy` for Django 4.0 compatibility

### DIFF
--- a/drfpasswordless/serializers.py
+++ b/drfpasswordless/serializers.py
@@ -1,5 +1,5 @@
 import logging
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.auth import get_user_model
 from django.core.exceptions import PermissionDenied
 from django.core.validators import RegexValidator

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -1,6 +1,6 @@
 from rest_framework import status
 from rest_framework.authtoken.models import Token
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from rest_framework.test import APITestCase
 from django.contrib.auth import get_user_model
 from django.urls import reverse


### PR DESCRIPTION
`ugettext_lazy` has been removed in Django 4.0, deprecated since Django 3.0, and has been identical to `gettext_lazy` since at [least Django 2.0](https://github.com/django/django/blob/stable/2.0.x/django/utils/translation/__init__.py#L100).