### PR TITLE
Pass context to serializer and bump version.

### DIFF
--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7]
+        python: [3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v1

--- a/drfpasswordless/__init__.py
+++ b/drfpasswordless/__init__.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 
 __title__ = 'drfpasswordless'
-__version__ = '1.5.8'
+__version__ = '1.5.9'
 __author__ = 'Aaron Ng'
 __license__ = 'MIT'
-__copyright__ = 'Copyright 2022 Aaron Ng'
+__copyright__ = 'Copyright 2023 Aaron Ng'
 
 # Version synonym
 VERSION = __version__

--- a/drfpasswordless/__version__.py
+++ b/drfpasswordless/__version__.py
@@ -1,3 +1,3 @@
-VERSION = (1, 5, 8)
+VERSION = (1, 5, 9)
 
 __version__ = '.'.join(map(str, VERSION))


### PR DESCRIPTION
- This passes the request context to the authentication serializer in a more standardized DRF-y way. This will enable you to get self.request from inside the auth serializer you use.
- It also bumps the version for release.
- And bumps python to 3.7 and 3.8 because tox doesn't seem to have 3.6 anymore.