### PR TITLE
Fix adding existing users to demo users

### DIFF
--- a/drfpasswordless/utils.py
+++ b/drfpasswordless/utils.py
@@ -41,7 +41,7 @@ def create_callback_token_for_user(user, alias_type, token_type):
     to_alias_field = getattr(api_settings, f'PASSWORDLESS_USER_{alias_type_u}_FIELD_NAME')
     if user.pk in api_settings.PASSWORDLESS_DEMO_USERS.keys():
         key = api_settings.PASSWORDLESS_DEMO_USERS[user.pk]
-        token = CallbackToken.objects.filter(user=user,key=key).first()
+        token = CallbackToken.objects.filter(user=user, key=key).first()
         if token:
             return token
         else:

--- a/drfpasswordless/utils.py
+++ b/drfpasswordless/utils.py
@@ -40,13 +40,14 @@ def create_callback_token_for_user(user, alias_type, token_type):
     alias_type_u = alias_type.upper()
     to_alias_field = getattr(api_settings, f'PASSWORDLESS_USER_{alias_type_u}_FIELD_NAME')
     if user.pk in api_settings.PASSWORDLESS_DEMO_USERS.keys():
-        token = CallbackToken.objects.filter(user=user).first()
+        key = api_settings.PASSWORDLESS_DEMO_USERS[user.pk]
+        token = CallbackToken.objects.filter(user=user,key=key).first()
         if token:
             return token
         else:
             return CallbackToken.objects.create(
                 user=user,
-                key=api_settings.PASSWORDLESS_DEMO_USERS[user.pk],
+                key=key,
                 to_alias_type=alias_type_u,
                 to_alias=getattr(user, to_alias_field),
                 type=token_type


### PR DESCRIPTION
This `.filter` call will always return the first token and in the case this isn't the expected demo user token key (whether it has changed in settings or the user previously logged in as a non-demo user) the expected demo user `CallbackToken` is never created.